### PR TITLE
Fix heap corruption inside CvLeaderHeadInfo copy ctor.

### DIFF
--- a/CvGameCoreDLL/CvXMLLoadUtility.h
+++ b/CvGameCoreDLL/CvXMLLoadUtility.h
@@ -34,6 +34,8 @@ class CvImprovementBonusInfo;
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 class CvXMLLoadUtility
 {
+private:
+	class Impl;
 //---------------------------------------PUBLIC INTERFACE---------------------------------
 public:
 	// default constructor
@@ -257,8 +259,24 @@ public:
 /************************************************************************************************/
 
 	// allocate and initialize a list from a tag pair in the xml
+	void SetVariableListTagPairInfo(CvDynamicArray<bool> *pList, const TCHAR* rootTagName,
+		int iagListLength, bool defaultListVal);
+	void SetVariableListTagPairInfo(CvDynamicArray<int> *pList, const TCHAR* rootTagName,
+		int tagListLength, int defaultListVal);
+
+	void SetVariableListTagPairEnum(CvDynamicArray<bool> *pList, const TCHAR* rootTagName,
+		int iagListLength, bool defaultListVal);
+	void SetVariableListTagPairEnum(CvDynamicArray<int> *pList, const TCHAR* rootTagName,
+		int tagListLength, int defaultListVal);
+
+	void SetVariableListTagPairForAudioScriptsInfo(CvDynamicArray<int> *pList, const TCHAR* szRootTagName,
+		int tagListLength, int iDefaultListVal = -1);
+
+
+
 	void SetVariableListTagPair(bool **ppbList, const TCHAR* szRootTagName,
 		int iInfoBaseSize, int iInfoBaseLength, bool bDefaultListVal = false);
+
 
 	// allocate and initialize a list from a tag pair in the xml
 	void SetVariableListTagPair(float **ppfList, const TCHAR* szRootTagName,
@@ -275,10 +293,6 @@ public:
 	// allocate and initialize a list from a tag pair in the xml for audio scripts
 	void SetVariableListTagPairForAudioScripts(int **ppiList, const TCHAR* szRootTagName,
 		CvString* m_paszTagList, int iTagListLength, int iDefaultListVal = -1);
-
-	// allocate and initialize a list from a tag pair in the xml
-	void SetVariableListTagPairForAudioScripts(int **ppiList, const TCHAR* szRootTagName,
-		int iInfoBaseLength, int iDefaultListVal = -1);
 
 	// allocate and initialize a list from a tag pair in the xml
 	void SetVariableListTagPair(bool **ppbList, const TCHAR* szRootTagName,

--- a/CvGameCoreDLL/FAssert.h
+++ b/CvGameCoreDLL/FAssert.h
@@ -24,6 +24,7 @@ bool FAssertDlg( const char*, const char*, const char*, unsigned int, bool& );
 	static bool bIgnoreAlways = false; \
 	if( !bIgnoreAlways && !(expr) ) \
 { \
+	std::cout << "ASSERT FAILED: " << #expr << " " << __FILE__ << " " << __LINE__ << std::endl; \
 	if( FAssertDlg( #expr, 0, __FILE__, __LINE__, bIgnoreAlways ) ) \
 { _asm int 3 } \
 } \
@@ -34,6 +35,7 @@ bool FAssertDlg( const char*, const char*, const char*, unsigned int, bool& );
 	static bool bIgnoreAlways = false; \
 	if( !bIgnoreAlways && !(expr) ) \
 { \
+	std::cout << "ASSERT FAILED: " << #expr << " " << msg << __FILE__ << " " << __LINE__ << std::endl; \
 	if( FAssertDlg( #expr, msg, __FILE__, __LINE__, bIgnoreAlways ) ) \
 { _asm int 3 } \
 } \


### PR DESCRIPTION
The current master branch have heap corruption inside CvLeaderHeadInfo::CvLeaderHeadInfo(CvLeaderHeadInfo const&), introduced by f92a4c38a67ab093de1720345a8544499f540db9 "Default values for Civ4LeaderHeadInfos.xml (incl. DLL)" from 2020-05-11.

Steps to reproduce:
Load the game with "Cronicles of Mankind" mod enabled.
Expected result:
Mod is loaded correctly.
Actual result:
Game crashes.
Additional info: may not be reproduced on all systems.

Analysis:
The crash stacktrace does not point to the root cause since the actual crash occurs later that the heap corruption, in addition under certain (unknown) conditions the crash may not occur at all.
The root cause is using memcpy to copy int fields inside CvLeaderHeadInfo::CvLeaderHeadInfo(CvLeaderHeadInfo const&). The size passed to the memcpy is incorrect, which causes heap corruption. Later the game may crash when trying to allocate/free some memory in heap.

Solution:
Avoid using memcpy, as it is prone to errors. Use RAII objects and implicitly defined copy ctor for CvLeaderHeadInfo.
Revert explicitly declared copy ctors added in f92a4c38a67ab093de1720345a8544499f540db9 as they are not used anywhere else.
Add methods to CvXMLLoadUtility for populating RAII arrays.

I didn't use std::vector here as it may not be properly used with save/load game utilities.

Use implicitly-defined copy ctors and RAII objects or storing data to avoid similar issues in the future.